### PR TITLE
Disabling joining of sub transactions

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -2,3 +2,4 @@ com.atomikos.icatch.log_base_name=breedingManagerTx
 com.atomikos.icatch.output_dir=${jta.log.directory}/breedingManager/debug/
 com.atomikos.icatch.log_base_dir=${jta.log.directory}/breedingManager/transactions/
 com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServiceFactory
+com.atomikos.icatch.serial_jta_transactions=false


### PR DESCRIPTION
Have updated the jta.properties so that we never attempt to create or join sub transactions.
MySQL does not support sub transactions and which results in errors when the application tries to create a
sub transaction. Further details can be found http://www.atomikos.com/Documentation/KnownProblems#MySQL_XA_bug

issue: BMS-1372
reviewer: MatthewB
