### PR TITLE
Removing restrictions on the number of active transactions.

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -3,3 +3,4 @@ com.atomikos.icatch.output_dir=${jta.log.directory}/breedingManager/debug/
 com.atomikos.icatch.log_base_dir=${jta.log.directory}/breedingManager/transactions/
 com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServiceFactory
 com.atomikos.icatch.serial_jta_transactions=false
+com.atomikos.icatch.max_actives=-1


### PR DESCRIPTION
Setting the max number of active transactions to infinite. We really do not want the upper limit to be controlled by Atomikos.

issue: BMS-1770
reviewer: NaymeshM
