### PR TITLE
Bms 1583 enable ignored tests

### DIFF
--- a/src/test/java/org/generationcp/breeding/manager/listmanager/util/GermplasmListExporterTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/listmanager/util/GermplasmListExporterTest.java
@@ -88,11 +88,11 @@ public class GermplasmListExporterTest {
 	@Mock
 	private FileService fileService;
 
-	@InjectMocks
-	private final GermplasmListExporter _germplasmListExporter = new GermplasmListExporter(GermplasmListExporterTest.LIST_ID);
+	@Mock
+	private GermplasmExportServiceImpl germplasmExportService;
 
 	@InjectMocks
-	private final GermplasmExportServiceImpl germplasmExportService = Mockito.spy(new GermplasmExportServiceImpl());
+	private final GermplasmListExporter _germplasmListExporter = new GermplasmListExporter(GermplasmListExporterTest.LIST_ID);
 
 	private GermplasmListExporter germplasmListExporter;
 


### PR DESCRIPTION
This requires the pull request from Commons to be merged first.

Enabling tests for BreadingManager. 
The review suggested that we move retrieveTemplate() method from GermplasmExportServiceImpl to FileService, which actually does file retrieval.
It also allows us to remove spies in tests for GermplasmExportServiceImpl (review suggestion)
