### PR TITLE
BMS-1885 Allow the user to choose from multiple valid list types to be imported in Germplasm Import

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/listimport/util/GermplasmListParser.java
+++ b/src/main/java/org/generationcp/breeding/manager/listimport/util/GermplasmListParser.java
@@ -3,6 +3,7 @@ package org.generationcp.breeding.manager.listimport.util;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,11 +11,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collection;
 
 import javax.annotation.Resource;
 
-import com.google.common.base.Strings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.generationcp.breeding.manager.listimport.validator.StockIDValidator;
@@ -33,12 +32,15 @@ import org.generationcp.commons.parsing.validation.ValueTypeValidator;
 import org.generationcp.commons.util.DateUtil;
 import org.generationcp.middleware.exceptions.MiddlewareQueryException;
 import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.manager.api.GermplasmListManager;
 import org.generationcp.middleware.manager.api.OntologyDataManager;
 import org.generationcp.middleware.pojos.Germplasm;
 import org.generationcp.middleware.pojos.UserDefinedField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Configurable;
+
+import com.google.common.base.Strings;
 
 /**
  * Class for parsing GermplsmList
@@ -53,11 +55,11 @@ public class GermplasmListParser extends AbstractExcelFileParser<ImportedGermpla
 	public static final String LIST_TYPE = "LIST TYPE";
 	private static final Logger LOG = LoggerFactory.getLogger(GermplasmListParser.class);
 	private static final int OBSERVATION_SHEET_NO = 1;
-	private static final String LISTTYPE = "LISTTYPE";
-	private static final String LISTNMS = "LISTNMS";
 	
 	private final Map<Integer, String> observationColumnMap = new HashMap<>();
 
+	@Resource
+	private GermplasmListManager germplasmListManager;
 	@Resource
 	private GermplasmDataManager germplasmDataManager;
 	@Resource
@@ -939,7 +941,7 @@ public class GermplasmListParser extends AbstractExcelFileParser<ImportedGermpla
 	}
 	
 	boolean validateListType(String listType) {
-		List<UserDefinedField> udFields = this.germplasmDataManager.getUserDefinedFieldByFieldTableNameAndType(LISTNMS, LISTTYPE);
+		List<UserDefinedField> udFields = this.germplasmListManager.getGermplasmListTypes();
 		for(UserDefinedField udField: udFields){
 			if(udField.getFcode().equalsIgnoreCase(listType)){
 				return true;

--- a/src/test/java/org/generationcp/breeding/manager/data/initializer/UserDefinedFieldTestDataInitializer.java
+++ b/src/test/java/org/generationcp/breeding/manager/data/initializer/UserDefinedFieldTestDataInitializer.java
@@ -2,32 +2,44 @@
 package org.generationcp.breeding.manager.data.initializer;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.generationcp.middleware.pojos.UserDefinedField;
 
 public class UserDefinedFieldTestDataInitializer {
 
-	public static UserDefinedField createUserDefinedField() {
-		return UserDefinedFieldTestDataInitializer.createUserDefinedField("LST", "Generic List");
+	public static Map<String, String> validListTypeMap = new HashMap<String, String>();
+	private List<UserDefinedField> validListType;
+	
+	static {
+		validListTypeMap.put("LST", "Generic List");
+		validListTypeMap.put("F1", "F1 NURSERY LIST");
+		validListTypeMap.put("F2", "F2 NURSERY LIST");
+		validListTypeMap.put("PN", "PEDIGREE NURSERY LIST");
 	}
-
-	public static UserDefinedField createUserDefinedField(final String fcode, final String fname) {
+	
+	public UserDefinedFieldTestDataInitializer(){
+		this.populateValidListType();
+	}
+	
+	public UserDefinedField createUserDefinedField(final String fcode, final String fname) {
 		final UserDefinedField udField = new UserDefinedField();
 		udField.setFcode(fcode);
 		udField.setFname(fname);
 		return udField;
 	}
-
-	public static List<UserDefinedField> createUserDefinedFieldList() {
-		final List<UserDefinedField> udFields = new ArrayList<UserDefinedField>();
-		udFields.add(UserDefinedFieldTestDataInitializer.createUserDefinedField());
-		return udFields;
+	
+	private void populateValidListType() {
+		this.validListType = new ArrayList<UserDefinedField>();
+		
+		for(Map.Entry<String, String> item: validListTypeMap.entrySet()){
+			this.validListType.add(this.createUserDefinedField(item.getKey(), item.getValue()));
+		}
 	}
-
-	public static List<UserDefinedField> createUserDefinedFieldList(final String fcode, final String fname) {
-		final List<UserDefinedField> udFields = new ArrayList<UserDefinedField>();
-		udFields.add(UserDefinedFieldTestDataInitializer.createUserDefinedField(fcode, fname));
-		return udFields;
+	
+	public List<UserDefinedField> getValidListType() {
+		return this.validListType;	
 	}
 }

--- a/src/test/java/org/generationcp/breeding/manager/listimport/util/GermplasmListParserTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/listimport/util/GermplasmListParserTest.java
@@ -3,17 +3,19 @@ package org.generationcp.breeding.manager.listimport.util;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.generationcp.breeding.manager.data.initializer.GermplasmDataInitializer;
-import org.generationcp.breeding.manager.data.initializer.UserDefinedFieldTestDataInitializer;
 import org.generationcp.breeding.manager.listimport.validator.StockIDValidator;
 import org.generationcp.breeding.manager.pojos.ImportedGermplasm;
 import org.generationcp.breeding.manager.pojos.ImportedGermplasmList;
 import org.generationcp.commons.parsing.FileParsingException;
 import org.generationcp.commons.util.DateUtil;
+import org.generationcp.breeding.manager.data.initializer.UserDefinedFieldTestDataInitializer;
 import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.manager.api.GermplasmListManager;
 import org.generationcp.middleware.manager.api.InventoryDataManager;
 import org.generationcp.middleware.manager.api.OntologyDataManager;
 import org.junit.Assert;
@@ -53,12 +55,15 @@ public class GermplasmListParserTest {
 	private InventoryDataManager inventoryDataManager;
 	
 	@Mock
+	private GermplasmListManager germplasmListManager;
+	@Mock
 	private StockIDValidator stockIdValidator;
 	
 	@InjectMocks
 	private final GermplasmListParser parser = new GermplasmListParser();
 
 	private ImportedGermplasmList importedGermplasmList;
+	private UserDefinedFieldTestDataInitializer userDefinedFieldTestDataInitializer = new UserDefinedFieldTestDataInitializer();
 
 	@Before
 	public void setUp() throws Exception {
@@ -68,7 +73,7 @@ public class GermplasmListParserTest {
 				false);
 		Mockito.when(this.germplasmDataManager.getGermplasmByGID(Matchers.anyInt())).thenReturn(GermplasmDataInitializer.createGermplasm(1));
 		Mockito.when(this.inventoryDataManager.getSimilarStockIds(Matchers.anyList())).thenReturn(new ArrayList<String>());
-		Mockito.when(this.germplasmDataManager.getUserDefinedFieldByFieldTableNameAndType(Matchers.anyString(), Matchers.anyString())).thenReturn(UserDefinedFieldTestDataInitializer.createUserDefinedFieldList());
+		Mockito.when(this.germplasmListManager.getGermplasmListTypes()).thenReturn(this.userDefinedFieldTestDataInitializer.getValidListType());
 
 	}
 
@@ -189,7 +194,9 @@ public class GermplasmListParserTest {
 	
 	@Test
 	public void testValidateListTypeFound(){
-		Assert.assertTrue("The listType should be accepted", this.parser.validateListType("LST"));
+		for(Map.Entry<String, String> item: this.userDefinedFieldTestDataInitializer.validListTypeMap.entrySet()){
+			Assert.assertTrue("The listType should be accepted", this.parser.validateListType(item.getKey()));
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
Replaced function call to exclude the snapshot list's list type in the result used in validation of the imported file's list type. Kindly Review, Thanks!
