### PR TITLE
BMS-2043 Added pedigree profile for bean crossExpansionProperties

### DIFF
--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -52,6 +52,7 @@
 		class="org.generationcp.middleware.util.CrossExpansionProperties">
 		<property name="wheatLevel" value="${wheat.generation.level}" />
 		<property name="defaultLevel" value="${default.generation.level}" />
+		<property name="profile" value="${pedigree.profile}" />
 	</bean>
 
 	<bean id="genotypicDataManager" factory-bean="managerFactory"


### PR DESCRIPTION
This is a prerequisite fix for BMS-2001.

Please review!
