### PR TITLE
BMS-2248 Germplasm list tree performance

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/customfields/ListSelectorComponent.java
+++ b/src/main/java/org/generationcp/breeding/manager/customfields/ListSelectorComponent.java
@@ -743,11 +743,11 @@ public abstract class ListSelectorComponent extends CssLayout implements Initial
 
 	public void addGermplasmListNodeToComponent(final List<GermplasmList> germplasmListChildren, final int parentGermplasmListId) {
 		List<UserDefinedField> listTypes = germplasmListManager.getGermplasmListTypes();
-		Map<Long, GermplasmListMetadata> allListMetaData = germplasmListManager.getAllGermplasmListMetadata();
+		Map<Integer, GermplasmListMetadata> allListMetaData = germplasmListManager.getAllGermplasmListMetadata();
 
 		for (final GermplasmList listChild : germplasmListChildren) {
 			if (this.doAddItem(listChild)) {
-				GermplasmListMetadata listMetadata = allListMetaData.get(Long.valueOf(listChild.getId()));
+				GermplasmListMetadata listMetadata = allListMetaData.get(listChild.getId());
 				final String listSize = listMetadata != null ? String.valueOf(listMetadata.getNumberOfEntries()) : "";
 				final String listOwner = listMetadata != null ? listMetadata.getOwnerName() : "";
 
@@ -887,11 +887,11 @@ public abstract class ListSelectorComponent extends CssLayout implements Initial
 		this.getGermplasmListSource().setItemCaption(ListSelectorComponent.LISTS, ListSelectorComponent.LISTS);
 		List<UserDefinedField> listTypes = germplasmListManager.getGermplasmListTypes();
 
-		Map<Long, GermplasmListMetadata> allListMetaData = germplasmListManager.getAllGermplasmListMetadata();
+		Map<Integer, GermplasmListMetadata> allListMetaData = germplasmListManager.getAllGermplasmListMetadata();
 
 		for (final GermplasmList parentList : germplasmListParent) {
 			if (this.doAddItem(parentList)) {
-				GermplasmListMetadata listMetadata = allListMetaData.get(Long.valueOf(parentList.getId()));
+				GermplasmListMetadata listMetadata = allListMetaData.get(parentList.getId());
 				final String listSize = listMetadata != null ? String.valueOf(listMetadata.getNumberOfEntries()) : "";
 				final String listOwner = listMetadata != null ? listMetadata.getOwnerName() : "";
 				this.getGermplasmListSource().addItem(

--- a/src/test/java/org/generationcp/breeding/manager/customfields/ListSelectorComponentTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/customfields/ListSelectorComponentTest.java
@@ -153,9 +153,9 @@ public class ListSelectorComponentTest {
 		Mockito.when(this.germplasmListManager.getGermplasmListByParentFolderIdBatched(parentGermplasmListId,
 				ListSelectorComponentTest.PROGRAM_UUID, ListSelectorComponent.BATCH_SIZE)).thenReturn(germplasmListChildren);
 
-		Long expectedNoOfEntries = 10L;
-		Map<Long, GermplasmListMetadata> allListMetaData = new HashMap<Long, GermplasmListMetadata>();
-		allListMetaData.put(childGermplasmListId.longValue(), new GermplasmListMetadata(childGermplasmListId.longValue(),
+		Integer expectedNoOfEntries = 10;
+		Map<Integer, GermplasmListMetadata> allListMetaData = new HashMap<Integer, GermplasmListMetadata>();
+		allListMetaData.put(childGermplasmListId, new GermplasmListMetadata(childGermplasmListId,
 				expectedNoOfEntries, "Child List Owner Name"));
 
 		Mockito.when(this.germplasmListManager.getAllGermplasmListMetadata()).thenReturn(allListMetaData);
@@ -165,7 +165,8 @@ public class ListSelectorComponentTest {
 		listManagerTreeComponent.setUserDataManager(userDataManager);
 		listManagerTreeComponent.addGermplasmListNode(parentGermplasmListId);
 		Item item = listManagerTreeComponent.getGermplasmListSource().getItem(childGermplasmListId);
-		Long actualNoOfEntries = Long.parseLong((String) item.getItemProperty(GermplasmListTreeTable.NUMBER_OF_ENTRIES_COL).getValue());
+		Integer actualNoOfEntries =
+				Integer.parseInt((String) item.getItemProperty(GermplasmListTreeTable.NUMBER_OF_ENTRIES_COL).getValue());
 		Assert.assertEquals("The number of entries should be the same", expectedNoOfEntries, actualNoOfEntries);
 
 	}
@@ -315,16 +316,17 @@ public class ListSelectorComponentTest {
 
 		Mockito.when(this.germplasmListManager.getAllTopLevelListsBatched(ListSelectorComponentTest.PROGRAM_UUID,
 				ListSelectorComponent.BATCH_SIZE)).thenReturn(germplasmListChildren);
-		Long expectedNoOfEntries = 10L;
-		Map<Long, GermplasmListMetadata> allListMetaData = new HashMap<Long, GermplasmListMetadata>();
-		allListMetaData.put(childGermplasmListId.longValue(), new GermplasmListMetadata(childGermplasmListId.longValue(),
+		Integer expectedNoOfEntries = 10;
+		Map<Integer, GermplasmListMetadata> allListMetaData = new HashMap<Integer, GermplasmListMetadata>();
+		allListMetaData.put(childGermplasmListId, new GermplasmListMetadata(childGermplasmListId,
 				expectedNoOfEntries, "Child List Owner Name"));
 		Mockito.when(this.germplasmListManager.getAllGermplasmListMetadata()).thenReturn(allListMetaData);
 
 		Mockito.when(userDataManager.getUserById(userId)).thenReturn(null);
 		listManagerTreeComponent.createGermplasmList();
 		Item item = listManagerTreeComponent.getGermplasmListSource().getItem(childGermplasmListId);
-		Long actualNoOfEntries = Long.parseLong((String) item.getItemProperty(GermplasmListTreeTable.NUMBER_OF_ENTRIES_COL).getValue());
+		Integer actualNoOfEntries =
+				Integer.parseInt((String) item.getItemProperty(GermplasmListTreeTable.NUMBER_OF_ENTRIES_COL).getValue());
 		Assert.assertEquals("The number of entries should be the same", expectedNoOfEntries, actualNoOfEntries);
 	}
 


### PR DESCRIPTION
Query optimization for loading list entry count and owner info in one go.
This is the SuperWoman fix @amehra !
