### PR TITLE
BMS-2648 - Default tab should be List Entries after closing all tabs.

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/listmanager/ListSelectionLayout.java
+++ b/src/main/java/org/generationcp/breeding/manager/listmanager/ListSelectionLayout.java
@@ -363,6 +363,7 @@ public class ListSelectionLayout extends VerticalLayout implements International
 	public void hideDetailsTabsheet() {
 		this.btnCloseAllTabs.setVisible(false);
 		this.detailsTabSheet.addStyleName(AppConstants.CssStyles.NO_TAB);
+		this.source.setModeView(ModeView.LIST_VIEW);
 	}
 
 	public void repaintTabsheet() {


### PR DESCRIPTION
When open first tab after closing all tabs, default tab view should be List Entries.

Issue: BMS-2648
Reviewer: Abhishek
