### PR TITLE
BMS-2867 - Preserve selected parent entries in crossing manager

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/crossingmanager/ParentTabComponent.java
+++ b/src/main/java/org/generationcp/breeding/manager/crossingmanager/ParentTabComponent.java
@@ -1000,20 +1000,20 @@ public class ParentTabComponent extends VerticalLayout implements InitializingBe
 			newItem.getItemProperty(ColumnLabels.STOCKID.getName()).setValue(entry.getInventoryInfo().getStockIDs());
 
 		}
-		
-		//move selection of previously checked entries when all the items are already added
-		//as checkbox fires value change immediately
-		preserveSelectedEntriesBeforeSaving(selectedEntryIds);
-		
+
+		// move selection of previously checked entries when all the items are already added
+		// as checkbox fires value change immediately
+		this.preserveSelectedEntriesBeforeSaving(selectedEntryIds);
+
 		this.resetUnsavedChangesFlag();
 		this.listDataTable.requestRepaint();
 	}
 
 	@SuppressWarnings("unchecked")
 	private void preserveSelectedEntriesBeforeSaving(final List<Integer> selectedEntryIds) {
-		final Collection<GermplasmListEntry> entries = (Collection<GermplasmListEntry>) 
-				this.listDataTable.getContainerDataSource().getItemIds();
-		for (GermplasmListEntry entry : entries) {
+		final Collection<GermplasmListEntry> entries =
+				(Collection<GermplasmListEntry>) this.listDataTable.getContainerDataSource().getItemIds();
+		for (final GermplasmListEntry entry : entries) {
 			if (selectedEntryIds.contains(entry.getEntryId())) {
 				this.listDataTable.select(entry);
 			}

--- a/src/test/java/org/generationcp/breeding/manager/crossingmanager/ParentTabComponentTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/crossingmanager/ParentTabComponentTest.java
@@ -343,13 +343,13 @@ public class ParentTabComponentTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testUpdateListDataTableWithPreservedSelectedEntriesAndCheckedSelectAll() {
-		final TableWithSelectAllLayout tableWithSelectAll = initializeTable();
+		final TableWithSelectAllLayout tableWithSelectAll = this.initializeTable();
 		// setup data
 		final List<GermplasmListData> savedListEntries =
 				GermplasmListDataTestDataInitializer.getGermplasmListDataList(ParentTabComponentTest.GERMPLASM_LIST_ID);
 		final Collection<GermplasmListEntry> listEntries = this.createListEntries(savedListEntries);
-		final List<Integer> selectedEntryIds = this.selectEntryIdsFromListEntries(listEntries, 
-				GermplasmListDataTestDataInitializer.NUM_OF_ENTRIES);
+		final List<Integer> selectedEntryIds =
+				this.selectEntryIdsFromListEntries(listEntries, GermplasmListDataTestDataInitializer.NUM_OF_ENTRIES);
 		final Table table = tableWithSelectAll.getTable();
 		this.addEntriesToTable(listEntries, table, selectedEntryIds);
 		// test
@@ -359,10 +359,10 @@ public class ParentTabComponentTest {
 		Assert.assertEquals("The selected entries should be preserved", selectedEntryIds.size(), newSelectedListEntries.size());
 		Assert.assertTrue("The select all should be selected", tableWithSelectAll.getCheckBox().booleanValue());
 	}
-	
+
 	private TableWithSelectAllLayout initializeTable() {
-		final TableWithSelectAllLayout tableWithSelectAll = new TableWithSelectAllLayout(
-				GermplasmListDataTestDataInitializer.NUM_OF_ENTRIES, ParentTabComponent.TAG_COLUMN_ID);
+		final TableWithSelectAllLayout tableWithSelectAll =
+				new TableWithSelectAllLayout(GermplasmListDataTestDataInitializer.NUM_OF_ENTRIES, ParentTabComponent.TAG_COLUMN_ID);
 		tableWithSelectAll.instantiateComponents();
 		tableWithSelectAll.addListeners();
 		this.parentTabComponent.initializeMainComponents();
@@ -379,7 +379,7 @@ public class ParentTabComponentTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testUpdateListDataTableWithPreservedSelectedEntriesAndUncheckedSelectAll() {
-		final TableWithSelectAllLayout tableWithSelectAll = initializeTable();
+		final TableWithSelectAllLayout tableWithSelectAll = this.initializeTable();
 		// setup data
 		final List<GermplasmListData> savedListEntries =
 				GermplasmListDataTestDataInitializer.getGermplasmListDataList(ParentTabComponentTest.GERMPLASM_LIST_ID);
@@ -399,7 +399,7 @@ public class ParentTabComponentTest {
 		final List<Integer> selectedEntryIds = new ArrayList<>();
 		int counterOfSelectedItems = 0;
 		for (final GermplasmListEntry germplasmListEntry : listEntries) {
-			if(counterOfSelectedItems < numberOfSelectedItems) {
+			if (counterOfSelectedItems < numberOfSelectedItems) {
 				selectedEntryIds.add(germplasmListEntry.getEntryId());
 			}
 			counterOfSelectedItems++;
@@ -407,14 +407,15 @@ public class ParentTabComponentTest {
 		return selectedEntryIds;
 	}
 
-	private void addEntriesToTable(final Collection<GermplasmListEntry> selectedListEntries, final Table table, List<Integer> selectedEntryIds) {
+	private void addEntriesToTable(final Collection<GermplasmListEntry> selectedListEntries, final Table table,
+			final List<Integer> selectedEntryIds) {
 		for (final GermplasmListEntry germplasmListEntry : selectedListEntries) {
 			final Item newItem = table.getContainerDataSource().addItem(germplasmListEntry);
-			
+
 			final CheckBox tag = new CheckBox();
 			newItem.getItemProperty(ParentTabComponent.TAG_COLUMN_ID).setValue(tag);
-			
-			if(selectedEntryIds.contains(germplasmListEntry.getEntryId())) {
+
+			if (selectedEntryIds.contains(germplasmListEntry.getEntryId())) {
 				table.select(germplasmListEntry);
 			}
 		}

--- a/src/test/java/org/generationcp/breeding/manager/data/initializer/GermplasmListDataTestDataInitializer.java
+++ b/src/test/java/org/generationcp/breeding/manager/data/initializer/GermplasmListDataTestDataInitializer.java
@@ -11,35 +11,34 @@ import org.generationcp.middleware.pojos.GermplasmListData;
 public class GermplasmListDataTestDataInitializer {
 
 	public static int NUM_OF_ENTRIES = 10;
-	
-	public static List<GermplasmListData> getGermplasmListDataList(int listId) {
+
+	public static List<GermplasmListData> getGermplasmListDataList(final int listId) {
 		final GermplasmList list = new GermplasmList(listId);
 		final List<GermplasmListData> listDataList = new ArrayList<>();
-		for (int i = 1; i <= NUM_OF_ENTRIES; i++) {
-			listDataList.add(getGermplasmListData(list, i + 10, i + 100, i));
+		for (int i = 1; i <= GermplasmListDataTestDataInitializer.NUM_OF_ENTRIES; i++) {
+			listDataList.add(GermplasmListDataTestDataInitializer.getGermplasmListData(list, i + 10, i + 100, i));
 		}
 		return listDataList;
 	}
-	
-	public static GermplasmListData getGermplasmListData(final GermplasmList list, final int id, 
-			final int gid, final int entryId) {
+
+	public static GermplasmListData getGermplasmListData(final GermplasmList list, final int id, final int gid, final int entryId) {
 		final GermplasmListData listData = new GermplasmListData();
 		listData.setId(id);
 		listData.setList(list);
 		listData.setGid(gid);
 		listData.setEntryId(entryId);
 		listData.setEntryCode(Integer.toString(entryId));
-		listData.setDesignation("LISTDATA-"+gid);
-		listData.setGroupName("GRP-"+id);
+		listData.setDesignation("LISTDATA-" + gid);
+		listData.setGroupName("GRP-" + id);
 		listData.setStatus(1);
 		listData.setLocalRecordId(list.getId());
-		
+
 		final ListDataInventory listDataInventory = new ListDataInventory(id, gid);
 		listDataInventory.setLotCount(id % 4);
 		listDataInventory.setActualInventoryLotCount(id % 3);
 		listDataInventory.setReservedLotCount(id % 2);
 		listData.setInventoryInfo(listDataInventory);
-		
+
 		return listData;
 	}
 }


### PR DESCRIPTION
Changes made are to preserve the selected parent entries in crossing manager upon saving of a parent. Included in the changes is making sure the Select All in the parents tab is selected only if all entries are selected.

Kindly review.
