### PR TITLE
Bms 3038 Set "Exclude self" checkbox as selected on Create Crosses

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/crossingmanager/CrossingMethodComponent.java
+++ b/src/main/java/org/generationcp/breeding/manager/crossingmanager/CrossingMethodComponent.java
@@ -81,7 +81,8 @@ public class CrossingMethodComponent extends VerticalLayout implements BreedingM
 		this.crossingMethodComboBox.setWidth("400px");
 
 		this.chkBoxMakeReciprocalCrosses = new CheckBox(this.messageSource.getMessage(Message.MAKE_CROSSES_CHECKBOX_LABEL));
-		this.chkBoxExcludeSelf = new CheckBox(this.messageSource.getMessage(Message.EXCLUDE_SELF_LABEL));
+		//By default set "Exclude self" checkbox as selected
+		this.chkBoxExcludeSelf = new CheckBox(this.messageSource.getMessage(Message.EXCLUDE_SELF_LABEL), true);
 
 		this.btnMakeCross = new Button(this.messageSource.getMessage(Message.MAKE_CROSSES_BUTTON_LABEL));
 		this.btnMakeCross.setData(CrossingMethodComponent.MAKE_CROSS_BUTTON_ID);


### PR DESCRIPTION
"Exclude self" checkbox from Create Crosses screen is set to selected by default as in most cases the user wish to enable this checkbox.
