### PR TITLE
BMS-3587 BMS-3535 variable cache per program and variable cache controllers

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/controller/VariableCacheController.java
+++ b/src/main/java/org/generationcp/breeding/manager/controller/VariableCacheController.java
@@ -1,13 +1,13 @@
 package org.generationcp.breeding.manager.controller;
 
-import java.util.List;
+import java.util.Arrays;
 
 import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -20,9 +20,9 @@ public class VariableCacheController {
 	private OntologyVariableDataManager ontologyVariableDataManager;
 
 	@ResponseBody
-	@RequestMapping(value = "/deleteVariablesFromCache", method = RequestMethod.POST)
-	public ResponseEntity<String> deleteVariablesFromCache(@RequestBody final List<Integer> variablesIds) {
-		this.ontologyVariableDataManager.deleteVariablesFromCache(variablesIds);
-		return new ResponseEntity<>(HttpStatus.OK);
+	@RequestMapping(value = "/{variablesIds}", method = RequestMethod.DELETE)
+	public ResponseEntity<String> deleteVariablesFromCache(@PathVariable final Integer[] variablesIds) {
+		this.ontologyVariableDataManager.deleteVariablesFromCache(Arrays.asList(variablesIds));
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 }


### PR DESCRIPTION
Please review

This PR contains Fix for BMS-3587 and BMS-3535. The later was incorporated into the former since code from it was needed and some modifications were needed in BMS-3535 too.

Other branches:
https://github.com/IntegratedBreedingPlatform/Workbench/pull/110
https://github.com/IntegratedBreedingPlatform/Middleware/pull/254
https://github.com/IntegratedBreedingPlatform/Fieldbook/pull/410
https://github.com/IntegratedBreedingPlatform/Commons/pull/111
https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/57