### PR TITLE
Parent List panels. The tabs are inverted

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/crossingmanager/MakeCrossesParentsComponent.java
+++ b/src/main/java/org/generationcp/breeding/manager/crossingmanager/MakeCrossesParentsComponent.java
@@ -149,9 +149,9 @@ public class MakeCrossesParentsComponent extends VerticalLayout implements Breed
 		HorizontalLayout parentListHLayout = new HorizontalLayout();
 		parentListHLayout.setWidth("100%");
 		parentListHLayout.setDebugId("parentListHLayout");
-		parentListHLayout.addComponent(maleParentTabSheet);
-		parentListHLayout.setSpacing(true);
 		parentListHLayout.addComponent(femaleParentTabSheet);
+		parentListHLayout.setSpacing(true);
+		parentListHLayout.addComponent(maleParentTabSheet);
 
 		final HeaderLabelLayout parentLabelLayout = new HeaderLabelLayout(AppConstants.Icons.ICON_LIST_TYPES, this.parentListsLabel);
 		parentLabelLayout.setDebugId("parentLabelLayout");


### PR DESCRIPTION
I inverted the Parent list tabs. The tabs were not in the correct order.

Please review.
Regards, Diego

Tagging: @clarysabel