### PR TITLE
Adjust prefix and suffix maximum lengths to 49 from 50 to accommodate…

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/listmanager/dialog/layout/AssignCodesNamingLayout.java
+++ b/src/main/java/org/generationcp/breeding/manager/listmanager/dialog/layout/AssignCodesNamingLayout.java
@@ -76,14 +76,14 @@ public class AssignCodesNamingLayout {
 		this.prefixTextField.setDebugId("prefixTextField");
 		this.prefixTextField.setImmediate(true);
 		this.prefixTextField.addValidator(new StringLengthValidator(
-				this.messageSource.getMessage(Message.ERROR_TOO_LONG, this.messageSource.getMessage(Message.CODE_PREFIX), 50), 0, 50,
+				this.messageSource.getMessage(Message.ERROR_TOO_LONG, this.messageSource.getMessage(Message.CODE_PREFIX), 49), 0, 49,
 				false));
 		
 		this.suffixTextField = new TextField();
 		this.suffixTextField.setDebugId("suffixTextField");
 		this.suffixTextField.setImmediate(true);
 		this.suffixTextField.addValidator(new StringLengthValidator(
-				this.messageSource.getMessage(Message.ERROR_TOO_LONG, this.messageSource.getMessage(Message.CODE_SUFFIX), 50), 0, 50,
+				this.messageSource.getMessage(Message.ERROR_TOO_LONG, this.messageSource.getMessage(Message.CODE_SUFFIX), 49), 0, 49,
 				true));
 		
 		this.numOfAllowedDigitsSelect = new Select();

--- a/src/test/java/org/generationcp/breeding/manager/listmanager/dialog/layout/AssignCodesNamingLayoutTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/listmanager/dialog/layout/AssignCodesNamingLayoutTest.java
@@ -83,14 +83,14 @@ public class AssignCodesNamingLayoutTest {
 		final Collection<Validator> prefixValidators = prefixTextField.getValidators();
 		Assert.assertNotNull(prefixValidators);
 		final StringLengthValidator prefixValidator = (StringLengthValidator) prefixValidators.iterator().next();
-		Assert.assertEquals(50, prefixValidator.getMaxLength());
+		Assert.assertEquals(49, prefixValidator.getMaxLength());
 
 		final TextField suffixTextField = this.namingLayout.getSuffixTextField();
 		Assert.assertTrue(suffixTextField.isImmediate());
 		final Collection<Validator> suffixValidators = suffixTextField.getValidators();
 		Assert.assertNotNull(suffixValidators);
 		final StringLengthValidator suffixValidator = (StringLengthValidator) suffixValidators.iterator().next();
-		Assert.assertEquals(50, suffixValidator.getMaxLength());
+		Assert.assertEquals(49, suffixValidator.getMaxLength());
 
 		final TextField startTextField = this.namingLayout.getStartNumberTextField();
 		Assert.assertTrue(startTextField.isImmediate());


### PR DESCRIPTION
… for an extra whitespace that could be appended to prefix/suffix value when the user chooses to add space between prefix/suffix and code.

This is to prevent DB error when saving.

BMS-4660