### PR TITLE
BMS-4682 Internal error when adding Column in View Germplasm

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/listmanager/GermplasmSearchLoadedItemsAddColumnSource.java
+++ b/src/main/java/org/generationcp/breeding/manager/listmanager/GermplasmSearchLoadedItemsAddColumnSource.java
@@ -98,8 +98,9 @@ public class GermplasmSearchLoadedItemsAddColumnSource implements AddColumnSourc
 
 			this.targetTable.setColumnHeader(columnLabel.getName(), columnLabel.getTermNameFromOntology(this.ontologyDataManager));
 
-			this.targetTable.refresh();
-
+			if(!this.targetTable.getItemIds().isEmpty()) {
+				this.targetTable.refresh();
+			}
 		}
 
 	}


### PR DESCRIPTION
Hi @nahuel-soldevilla and @clarysabel 

I added a validation when adding a column before use search in view Germplasm. I did it because the LazyQueryContainer is not created yet and when you add a column invoke the table refresh that uses the LazyQueryContainer. On another hand, you don't need to refresh the table if not had items there.

Please, review
thanks, Diego